### PR TITLE
NOSCRIPT FIX: Updated the non-JS fallback html

### DIFF
--- a/code/RecaptchaField.php
+++ b/code/RecaptchaField.php
@@ -115,7 +115,7 @@ class RecaptchaField extends FormField {
 		// noscript fallback
 		$html .= <<<EOF
 <noscript>
-  <div style="width: 302px; height: 422px;">
+  <div style="width: 302px; height: 462px;">
     <div style="width: 302px; height: 422px; position: relative;">
       <div style="width: 302px; height: 422px; position: absolute;">
         <iframe src="{$iframeURL}"
@@ -123,17 +123,18 @@ class RecaptchaField extends FormField {
                 style="width: 302px; height:422px; border-style: none;">
         </iframe>
       </div>
-      <div style="width: 300px; height: 60px; border-style: none;
-                  bottom: 12px; left: 25px; margin: 0px; padding: 0px; right: 25px;
-                  background: #f9f9f9; border: 1px solid #c1c1c1; border-radius: 3px;">
-        <textarea id="g-recaptcha-response" name="g-recaptcha-response"
-                  class="g-recaptcha-response"
-                  style="width: 250px; height: 40px; border: 1px solid #c1c1c1;
-                         margin: 10px 25px; padding: 0px; resize: none;" >
-        </textarea>
-      </div>
+    </div>
+    <div style="border-style: none; bottom: 12px; left: 25px; margin: 0px; padding: 0px;
+                right: 25px; background: #f9f9f9; border: 1px solid #c1c1c1;
+                border-radius: 3px; height: 60px; width: 300px;">
+      <textarea id="g-recaptcha-response" name="g-recaptcha-response"
+                class="g-recaptcha-response"
+                style="width: 250px; height: 40px; border: 1px solid #c1c1c1;
+                margin: 10px 25px; padding: 0px; resize: none;">
+      </textarea>
     </div>
   </div>
+  <br>
 </noscript>
 EOF;
 


### PR DESCRIPTION
It appears the [non-JS reCAPTCHA fallback FAQ](https://developers.google.com/recaptcha/docs/faq#can-recaptcha-support-users-that-dont-have-javascript-enabled) has outdated html.

I've copied the markup from the most up to date reCAPTCHA from the [demo page](https://www.google.com/recaptcha/api2/demo) and verified spam protection is working on my local dev site.
